### PR TITLE
Add JABBA support.

### DIFF
--- a/src/main/java/spatialiocompat/core/SIOCompat.java
+++ b/src/main/java/spatialiocompat/core/SIOCompat.java
@@ -1,14 +1,15 @@
 package spatialiocompat.core;
 
-import spatialiocompat.modules.CarpenterBlocks;
-import spatialiocompat.modules.IronChests;
-import spatialiocompat.modules.Thaumcraft;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import spatialiocompat.modules.CarpenterBlocks;
+import spatialiocompat.modules.IronChests;
+import spatialiocompat.modules.Jabba;
+import spatialiocompat.modules.Thaumcraft;
 
 @Mod(modid = SIOCompat.modid, name = SIOCompat.name, version = SIOCompat.version, dependencies = SIOCompat.dependencies)
 public class SIOCompat 
@@ -36,6 +37,9 @@ public class SIOCompat
         
         if ( Loader.isModLoaded( "Thaumcraft" ) )
     		Thaumcraft.register();
+
+        if ( Loader.isModLoaded( "JABBA" ) )
+            Jabba.register();
     }
 
 	@EventHandler

--- a/src/main/java/spatialiocompat/modules/Jabba.java
+++ b/src/main/java/spatialiocompat/modules/Jabba.java
@@ -1,0 +1,29 @@
+package spatialiocompat.modules;
+
+import spatialiocompat.core.SIOBaseModule;
+
+/**
+ * JABBA (Just Another Better Barrel Attempt)
+ *  a mod by ProfMobius
+ *
+ * Tested by TehSomeLuigi.
+ * No issues found.
+ *
+ * BSpace barrels function properly -- if one BSpace barrel is
+ * stored in a SIO Cell, items can still be retrieved from any
+ * BSpace barrels remaining in the world. They do not lose their
+ * link. Tested both with both linked barrels in the SIO Cell
+ * and one of two barrels in the SIO Cell.
+ *  In other words: It works!
+ *
+ * Friday the 1st of August 2014
+ *  JABBA version 1.1.4 for MC 1.7.10
+ *
+ */
+public class Jabba extends SIOBaseModule
+{
+    public static void register()
+    {
+        addTileEntity("mcp.mobius.betterbarrels.common.blocks.TileEntityBarrel");
+    }
+}


### PR DESCRIPTION
Simply adds JABBA support. For the record, even tested with the BSpace (linked) barrels and all works fine.

As a side suggestion, this compatibility mod is pretty hidden. Maybe you could add a link to it from the Downloads page or directly on the Homepage?

Cheers.
